### PR TITLE
refactor(packing_algorithm): simplify logic with bin.try_packing(item) api

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -96,4 +96,21 @@ impl<'a> Bin<'a> {
         self.items.push(item);
         Some(())
     }
+    /**
+
+    Returns a new bin that is the same dimensions as the original bin, but without any items.
+
+    ```rust
+        use bin_packer_3d::bin::Bin;
+        use bin_packer_3d::item::{Item, ItemId};
+        let bin = Bin::new([24.0, 10.0, 4.0]);
+        let new_bin = bin.clone_as_empty_bin();
+    ```
+    **/
+    pub fn clone_as_empty_bin(&self) -> Self {
+        Self {
+            blocks: self.blocks.clone(),
+            items: vec![],
+        }
+    }
 }

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -1,4 +1,5 @@
 use crate::block::{Block, Dimension};
+use crate::error::{Error, Result};
 use crate::item::Item;
 
 /// Represents an bin that a user can insert items into.
@@ -8,35 +9,91 @@ use crate::item::Item;
 /// ```
 
 #[derive(Clone, Debug)]
-pub struct Bin {
-    /// Represents the cuboid of this Bin.
-    block: Block,
+pub struct Bin<'a> {
+    /// Represents the cuboid of this bin.
+    blocks: Vec<Block>,
+    /// Represents the items that are currently packed inside this bin.
+    pub items: Vec<Item<'a>>,
 }
 
-impl Bin {
+impl<'a> Bin<'a> {
     /// Creates a new Bin from it's dimensions.
     pub fn new(dims: [Dimension; 3]) -> Self {
         Self {
-            block: Block::new(dims[0], dims[1], dims[2]),
+            blocks: vec![Block::new(dims[0], dims[1], dims[2])],
+            items: vec![],
         }
     }
 
-    /// Returns whether or not the Bin's dimensions can emcompass or match the Bin.
-    pub fn does_item_fit(&self, item: &Item<'_>) -> bool {
-        self.block.does_it_fit(&item.block)
+    /**
+    Returns whether or not the Bin's dimensions can emcompass or match the item.
+
+    An item that fits into a bin:
+    ```rust
+        use bin_packer_3d::bin::Bin;
+        use bin_packer_3d::item::Item;
+        let item = Item::new("item1", [1.0, 2.0, 3.0]);
+        let bin = Bin::new([1.0, 2.0, 3.0]);
+        assert!(bin.fits(&item));
+    ```
+    An item that does not fit into a bin:
+    ```rust
+        use bin_packer_3d::bin::Bin;
+        use bin_packer_3d::item::Item;
+        let item = Item::new("item2", [4.0, 12.0, 14.0]);
+        let bin = Bin::new([3.0, 12.0, 14.0]);
+        assert!(!bin.fits(&item));
+    ```
+    **/
+    pub fn fits(&self, item: &Item<'_>) -> bool {
+        self.blocks
+            .iter()
+            .any(|block| block.does_it_fit(&item.block))
     }
 
-    /// Returns the remaining bins after the item has been added to the current bin.
-    /// Returns None if the item is too big to fit into the bin.
-    pub fn best_fit(self, item: &Item<'_>) -> Option<Vec<Bin>> {
-        self.block
-            .best_fit(&item.block)
-            .map(|blocks| blocks.into_iter().map(|block| Bin::from(block)).collect())
-    }
-}
+    /**
+     Add the item to the bin
+     Returns None if the item cannot be packed into the bin.
 
-impl From<Block> for Bin {
-    fn from(block: Block) -> Self {
-        Bin::new([block.dims[0], block.dims[1], block.dims[2]])
+    ```rust
+        use bin_packer_3d::bin::Bin;
+        use bin_packer_3d::item::{Item, ItemId};
+
+        let item_1 = Item::new("item1", [24.0, 10.0, 2.0]);
+        let item_2 = Item::new("item2", [24.0, 10.0, 2.0]);
+        let item_3 = Item::new("item3", [24.0, 10.0, 2.0]);
+        let mut bin = Bin::new([24.0, 10.0, 4.0]);
+        assert!(bin.try_packing(item_1).is_some());
+        assert!(bin.try_packing(item_2).is_some());
+        assert_eq!(bin.try_packing(item_3), None);
+        assert_eq!(
+            bin.items
+                .into_iter()
+                .map(|item| item.id)
+                .collect::<Vec<&ItemId>>(),
+            vec!["item1", "item2"]
+        );
+    ```
+    **/
+    pub fn try_packing(&mut self, item: Item<'a>) -> Option<()> {
+        let block_to_pack_index =
+            self.blocks
+                .iter()
+                .enumerate()
+                .find_map(|(block_index, block)| {
+                    if block.does_it_fit(&item.block) {
+                        Some(block_index)
+                    } else {
+                        None
+                    }
+                })?;
+        let block_to_pack = self.blocks.remove(block_to_pack_index);
+        self.blocks.append(
+            &mut block_to_pack
+                .best_fit(&item.block)
+                .expect("Invalid state - the block doesn't fit the item."),
+        );
+        self.items.push(item);
+        Some(())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,7 @@ pub enum Error {
     /// It is an invariant that each item must be able to fit within the bin's dimensions. If one or
     /// more items don't fit into the bin, then this error will be raised.
     ///
-    ItemsNoFit(String),
+    AllItemsMustFit(String),
 }
 
 /// This Result type is a convenience type that uses the BinPacker's Error type as a default.

--- a/src/packing_algorithm.rs
+++ b/src/packing_algorithm.rs
@@ -26,17 +26,15 @@ bins. (first bin is first nested list, second is the second, etc.)
 ```
 **/
 
-pub fn packing_algorithm<'a>(bin: Bin, items: &'a Vec<Item<'_>>) -> Result<Vec<Vec<&'a ItemId>>> {
-    if !items.iter().all(|item| bin.does_item_fit(item)) {
-        return Err(Error::ItemsNoFit(format!(
+pub fn packing_algorithm<'a>(
+    bin: Bin<'a>,
+    items: &'a Vec<Item<'_>>,
+) -> Result<Vec<Vec<&'a ItemId>>> {
+    if !items.iter().all(|item| bin.fits(item)) {
+        return Err(Error::AllItemsMustFit(format!(
             "All items must fit within the bin dimensions."
         )));
     }
-
-    // remaining_bins is a list of Bins, representing the available space into which items can be
-    // added.
-
-    let mut remaining_bins = Vec::<Bin>::new();
 
     let mut items_to_pack = items.clone();
 
@@ -44,35 +42,47 @@ pub fn packing_algorithm<'a>(bin: Bin, items: &'a Vec<Item<'_>>) -> Result<Vec<V
 
     items_to_pack.sort_by(|a, b| b.cmp(&a));
 
-    let mut packed_items: Vec<Vec<&ItemId>> = Vec::new();
+    let mut packed_bins: Vec<Bin<'a>> = Vec::new();
+    let mut bin_currently_packing = bin.clone();
 
-    while !items_to_pack.is_empty() {
-        if remaining_bins.is_empty() {
-            remaining_bins.push(bin.clone());
-            packed_items.push(vec![]);
+    loop {
+        match (
+            items_to_pack.is_empty(),
+            bin_currently_packing.items.is_empty(),
+        ) {
+            (true, true) => break,
+            (true, false) => {
+                // no more items to pack:
+                packed_bins.push(bin_currently_packing);
+                break;
+            }
+            (false, _) => {
+                if let Some(packed_item_index) =
+                    items_to_pack
+                        .clone()
+                        .into_iter()
+                        .enumerate()
+                        .find_map(|(item_index, item)| {
+                            bin_currently_packing.try_packing(item).map(|_| item_index)
+                        })
+                {
+                    items_to_pack.remove(packed_item_index);
+                } else {
+
+                    // We can't fit any more items into the current bin - add it to our packed_bins, and
+                    // open up a new bin to pack.
+
+                    let packed_bin = std::mem::replace(&mut bin_currently_packing, bin.clone());
+                    packed_bins.push(packed_bin);
+                }
+            }
         }
-        remaining_bins = remaining_bins
-            .into_iter()
-            .flat_map(|bin| {
-                items_to_pack
-                    .clone()
-                    .into_iter()
-                    .enumerate()
-                    .find_map(|(i, item)| {
-                        let remaining_bins = bin.clone().best_fit(&item)?;
-                        // Add the id to our packed_items:
-                        packed_items
-                            .last_mut()
-                            .expect("packed_items must not be empty!")
-                            .push(item.id);
-                        items_to_pack.remove(i);
-                        Some(remaining_bins)
-                    })
-                    // If no items can be fitted into the bin, then skip the bin:
-                    .unwrap_or(vec![])
-            })
-            .collect::<Vec<Bin>>();
     }
 
-    Ok(packed_items)
+    // map the bins back into their Vec<ItemId> representations:
+
+    Ok(packed_bins
+        .into_iter()
+        .map(|bin| bin.items.into_iter().map(|item| item.id).collect())
+        .collect())
 }

--- a/src/packing_algorithm.rs
+++ b/src/packing_algorithm.rs
@@ -43,7 +43,7 @@ pub fn packing_algorithm<'a>(
     items_to_pack.sort_by(|a, b| b.cmp(&a));
 
     let mut packed_bins: Vec<Bin<'a>> = Vec::new();
-    let mut bin_currently_packing = bin.clone();
+    let mut bin_currently_packing = bin.clone_as_empty_bin();
 
     loop {
         match (
@@ -57,22 +57,21 @@ pub fn packing_algorithm<'a>(
                 break;
             }
             (false, _) => {
-                if let Some(packed_item_index) =
-                    items_to_pack
-                        .clone()
-                        .into_iter()
-                        .enumerate()
-                        .find_map(|(item_index, item)| {
-                            bin_currently_packing.try_packing(item).map(|_| item_index)
-                        })
+                if let Some(packed_item_index) = items_to_pack
+                    .clone()
+                    .into_iter()
+                    .enumerate()
+                    .find_map(|(item_index, item)| {
+                        bin_currently_packing.try_packing(item).map(|_| item_index)
+                    })
                 {
                     items_to_pack.remove(packed_item_index);
                 } else {
-
                     // We can't fit any more items into the current bin - add it to our packed_bins, and
                     // open up a new bin to pack.
 
-                    let packed_bin = std::mem::replace(&mut bin_currently_packing, bin.clone());
+                    let packed_bin =
+                        std::mem::replace(&mut bin_currently_packing, bin.clone_as_empty_bin());
                     packed_bins.push(packed_bin);
                 }
             }

--- a/tests/test_packing_algorithm.rs
+++ b/tests/test_packing_algorithm.rs
@@ -3,6 +3,9 @@ use bin_packer_3d::error::{Error, Result};
 use bin_packer_3d::item::{Item, ItemId};
 use bin_packer_3d::packing_algorithm::packing_algorithm;
 
+
+/// test packing_algorithm API
+
 #[test]
 fn test_pack_items_no_items() -> Result<()> {
     let items = vec![];
@@ -202,5 +205,28 @@ fn test_flat_bin() -> Result<()> {
     let res = packing_algorithm(Bin::new([3.5, 9.5, 12.5]), &items)?;
     assert_eq!(res.len(), 2);
     assert_eq!(res.first().map(|packed| packed.len()), Some(2));
+    Ok(())
+}
+
+/// Test Bin API
+
+// NOTE: It's probably worth re-organizing our integration tests, perhaps grouping them by module.
+
+#[test]
+fn test_bin_try_packing() -> Result<()> {
+    let item_1 = Item::new("item1", [24.0, 10.0, 2.0]);
+    let item_2 = Item::new("item2", [24.0, 10.0, 2.0]);
+    let item_3 = Item::new("item3", [24.0, 10.0, 2.0]);
+    let mut bin = Bin::new([24.0, 10.0, 4.0]);
+    assert!(bin.try_packing(item_1).is_some());
+    assert!(bin.try_packing(item_2).is_some());
+    assert_eq!(bin.try_packing(item_3), None);
+    assert_eq!(
+        bin.items
+            .into_iter()
+            .map(|item| item.id)
+            .collect::<Vec<&ItemId>>(),
+        vec!["item1", "item2"]
+    );
     Ok(())
 }

--- a/tests/test_packing_algorithm.rs
+++ b/tests/test_packing_algorithm.rs
@@ -7,10 +7,7 @@ use bin_packer_3d::packing_algorithm::packing_algorithm;
 fn test_pack_items_no_items() -> Result<()> {
     let items = vec![];
     let res = packing_algorithm(Bin::new([3.0, 4.5, 5.0]), &items)?;
-    assert_eq!(
-        res,
-        Vec::<Vec<&ItemId>>::new(),
-    );
+    assert_eq!(res, Vec::<Vec<&ItemId>>::new());
     Ok(())
 }
 
@@ -20,7 +17,7 @@ fn test_pack_items_no_fit() -> Result<()> {
     let err = packing_algorithm(Bin::new([3.0, 4.5, 5.0]), &items).unwrap_err();
     assert_eq!(
         err,
-        Error::ItemsNoFit(format!("All items must fit within the bin dimensions."))
+        Error::AllItemsMustFit(format!("All items must fit within the bin dimensions."))
     );
     Ok(())
 }


### PR DESCRIPTION
This PR cleanup up some of the CPU micromanaging in `packing_algorithm` by implementing a `Bin.fits()` and `Bin.try_packing(Item)` API on our Bin.