### PR TITLE
refactor(block): allow floats and ints

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -1,5 +1,5 @@
 use crate::block::{Block, Dimension};
-use crate::error::{Error, Result};
+use crate::error::Result;
 use crate::item::Item;
 
 /// Represents an bin that a user can insert items into.
@@ -18,7 +18,7 @@ pub struct Bin<'a> {
 
 impl<'a> Bin<'a> {
     /// Creates a new Bin from it's dimensions.
-    pub fn new(dims: [Dimension; 3]) -> Self {
+    pub fn new<F: Into<Dimension> + Copy>(dims: [F; 3]) -> Self {
         Self {
             blocks: vec![Block::new(dims[0], dims[1], dims[2])],
             items: vec![],

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,11 +1,12 @@
 use crate::block::BestFitKind::{DoubledFit, ExactFit, GreaterThanFit};
+use crate::error::{ Result};
 use std::cmp::Ordering::Equal;
 
 // TODO: explore using a fixed-decimal type. (eg: u16 for the integer, and u8 for the two decmial
 // places)
 
-pub type Dimension = f32;
-type Volume = f32;
+pub type Dimension = f64;
+type Volume = f64;
 
 /// Represents the kinds of fits we support in the best-fit section of our algorithm.
 /// usize contains the index of the dim where the best-fit has been matched.
@@ -30,8 +31,9 @@ pub struct Block {
 }
 
 impl Block {
-    pub fn new(d1: Dimension, d2: Dimension, d3: Dimension) -> Self {
-        let mut dims = [d1, d2, d3];
+    pub fn new<F: Into<f64>>(d1: F, d2: F, d3: F) -> Self {
+        // TODO: fail on negative values
+        let mut dims = [d1.into(), d2.into(), d3.into()];
         dims.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Equal));
         Self { dims }
     }

--- a/src/block.rs
+++ b/src/block.rs
@@ -31,7 +31,7 @@ pub struct Block {
 }
 
 impl Block {
-    pub fn new<F: Into<f64>>(d1: F, d2: F, d3: F) -> Self {
+    pub fn new<F: Into<Dimension>>(d1: F, d2: F, d3: F) -> Self {
         // TODO: fail on negative values
         let mut dims = [d1.into(), d2.into(), d3.into()];
         dims.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Equal));
@@ -63,13 +63,13 @@ impl Block {
     If an item doesn't fit, we return None.
 
     /// ```rust
-    ///   let item = Block::new(1 as Dimension, 1 as Dimension, 1 as Dimension);
-    ///   let container = Block::new(1 as Dimension, 2 as Dimension, 2 as Dimension);
+    ///   let item = Block::new(1, 1, 1);
+    ///   let container = Block::new(1, 2, 2);
     ///   assert_eq!(
     ///       container.best_fit(&item),
     ///       Some(vec![
-    ///           Block::new(1 as Dimension, 1 as Dimension, 1 as Dimension),
-    ///           Block::new(1 as Dimension, 1 as Dimension, 2 as Dimension)
+    ///           Block::new(1, 1, 1),
+    ///           Block::new(1, 1, 2)
     ///       ])
     ///   );
     /// ```

--- a/src/item.rs
+++ b/src/item.rs
@@ -23,7 +23,7 @@ pub struct Item<'a> {
 
 impl<'a> Item<'a> {
     /// Create an item given it's id and dimensions.
-    pub fn new(id: &'a str, dims: [Dimension; 3]) -> Self {
+    pub fn new<F: Into<Dimension> + Copy>(id: &'a str, dims: [F; 3]) -> Self {
         Self {
             id,
             block: Block::new(dims[0], dims[1], dims[2]),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,11 +27,11 @@ strategy, which some rotational optimizations.
     use bin_packer_3d::item::Item;
     use bin_packer_3d::packing_algorithm::packing_algorithm;
 
-    let deck = Item::new("deck", [2.0, 8.0, 12.0]);
-    let die = Item::new("die", [8.0, 8.0, 8.0]);
+    let deck = Item::new("deck", [2, 8, 12]);
+    let die = Item::new("die", [8, 8, 8]);
     let items = vec![deck.clone(), deck.clone(), die, deck.clone(), deck];
 
-    let packed_items = packing_algorithm(Bin::new([8.0, 8.0, 12.0]), &items);
+    let packed_items = packing_algorithm(Bin::new([8, 8, 12]), &items);
     assert_eq!(packed_items, Ok(vec![vec!["deck", "deck", "deck", "deck"], vec!["die"]]));
 ```
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,20 +1,20 @@
-use crate::block::{Block, Dimension};
-use crate::item::Item;
 use crate::bin::Bin;
+use crate::block::{Block, Dimension};
 use crate::error::Result;
+use crate::item::Item;
 
 mod block {
     use super::*;
 
     #[test]
     fn test_block_creation() -> Result<()> {
-        Block::new(1 as Dimension, 2 as Dimension, 3 as Dimension);
+        Block::new(1, 2, 3);
         Ok(())
     }
 
     #[test]
     fn test_item_creation() -> Result<()> {
-        Item::new("asdf", [1 as Dimension, 2 as Dimension, 3 as Dimension]);
+        Item::new("asdf", [1, 2, 3]);
         Ok(())
     }
 
@@ -41,7 +41,7 @@ mod block {
     #[test]
     fn test_block_does_it_fit() -> Result<()> {
         // test that when an item fits, it returns true
-        let item = Block::new(3.5, 14 as Dimension, 12.7);
+        let item = Block::new(3.5, 14.0, 12.7);
         let container = Block::new(4 as Dimension, 22 as Dimension, 14 as Dimension);
         assert!(container.does_it_fit(&item));
         Ok(())
@@ -99,14 +99,14 @@ mod block {
     fn test_best_fit_first_fit_greater_than() -> Result<()> {
         // test that the "greater than" match clause of the first fit returns the
         // correct remaining space.
-        let item = Block::new(1.25, 7 as Dimension, 10 as Dimension);
+        let item = Block::new(1.25, 7.0, 10.0);
         let container = Block::new(3.5, 9.5, 12.5);
         assert_eq!(
             container.best_fit(&item),
             Some(vec![
-                Block::new(1.25, 2.5, 7 as Dimension),
+                Block::new(1.25, 2.5, 7.0),
                 Block::new(2.5, 3.5, 12.5),
-                Block::new(2.25, 7 as Dimension, 12.5)
+                Block::new(2.25, 7.0, 12.5)
             ])
         );
         Ok(())

--- a/tests/test_packing_algorithm.rs
+++ b/tests/test_packing_algorithm.rs
@@ -9,15 +9,15 @@ use bin_packer_3d::packing_algorithm::packing_algorithm;
 #[test]
 fn test_pack_items_no_items() -> Result<()> {
     let items = vec![];
-    let res = packing_algorithm(Bin::new([3.0, 4.5, 5.0]), &items)?;
+    let res = packing_algorithm(Bin::new([3, 4, 5]), &items)?;
     assert_eq!(res, Vec::<Vec<&ItemId>>::new());
     Ok(())
 }
 
 #[test]
 fn test_pack_items_no_fit() -> Result<()> {
-    let items = vec![Item::new("item1", [3.0, 4.5, 6.0])];
-    let err = packing_algorithm(Bin::new([3.0, 4.5, 5.0]), &items).unwrap_err();
+    let items = vec![Item::new("item1", [3, 4, 6])];
+    let err = packing_algorithm(Bin::new([3, 4, 5]), &items).unwrap_err();
     assert_eq!(
         err,
         Error::AllItemsMustFit(format!("All items must fit within the bin dimensions."))
@@ -27,16 +27,16 @@ fn test_pack_items_no_fit() -> Result<()> {
 
 #[test]
 fn test_pack_items_one_item() -> Result<()> {
-    let items = vec![Item::new("item1", [3.0, 4.5, 5.0])];
-    let res = packing_algorithm(Bin::new([3.0, 4.5, 5.0]), &items)?;
+    let items = vec![Item::new("item1", [3, 4, 5])];
+    let res = packing_algorithm(Bin::new([3, 4, 5]), &items)?;
     assert_eq!(res, vec![vec!["item1"]]);
     Ok(())
 }
 
 #[test]
 fn test_pack_items_two_item_exact() -> Result<()> {
-    let bin = Bin::new([13.0, 26.0, 31.0]);
-    let item_1 = Item::new("item1", [13.0, 13.0, 31.0]);
+    let bin = Bin::new([13, 26, 31]);
+    let item_1 = Item::new("item1", [13, 13, 31]);
     let items = vec![item_1.clone(), item_1];
     let res = packing_algorithm(bin, &items)?;
     assert_eq!(res, vec![vec!["item1", "item1"]]);
@@ -45,40 +45,40 @@ fn test_pack_items_two_item_exact() -> Result<()> {
 
 #[test]
 fn test_two_items_two_bins() -> Result<()> {
-    let item = Item::new("item1", [13.0, 13.0, 31.0]);
+    let item = Item::new("item1", [13, 13, 31]);
     let items = vec![item.clone(), item];
-    let res = packing_algorithm(Bin::new([13.0, 13.0, 31.0]), &items)?;
+    let res = packing_algorithm(Bin::new([13, 13, 31]), &items)?;
     assert_eq!(res, vec![vec!["item1"], vec!["item1"]]);
     Ok(())
 }
 
 #[test]
 fn test_three_items_one_bin() -> Result<()> {
-    let item_1 = Item::new("item1", [13.0, 13.0, 31.0]);
-    let item_2 = Item::new("item2", [8.0, 13.0, 31.0]);
-    let item_3 = Item::new("item3", [5.0, 13.0, 31.0]);
+    let item_1 = Item::new("item1", [13, 13, 31]);
+    let item_2 = Item::new("item2", [8, 13, 31]);
+    let item_3 = Item::new("item3", [5, 13, 31]);
     let items = vec![item_1, item_2, item_3];
-    let res = packing_algorithm(Bin::new([13.0, 26.0, 31.0]), &items)?;
+    let res = packing_algorithm(Bin::new([13, 26, 31]), &items)?;
     assert_eq!(res, vec![vec!["item1", "item2", "item3"]]);
     Ok(())
 }
 
 #[test]
 fn test_one_overflow() -> Result<()> {
-    let item = Item::new("item1", [1.0, 1.0, 1.0]);
+    let item = Item::new("item1", [1, 1, 1]);
     let items = (0..=27).map(|_| item.clone()).collect();
-    let res = packing_algorithm(Bin::new([3.0, 3.0, 3.0]), &items)?;
+    let res = packing_algorithm(Bin::new([3, 3, 3]), &items)?;
     assert_eq!(res, vec![["item1"; 27].to_vec(), vec!["item1"]]);
     Ok(())
 }
 
 #[test]
 fn test_odd_sizes() -> Result<()> {
-    let item_1 = Item::new("item1", [3.0, 8.0, 10.0]);
-    let item_2 = Item::new("item2", [1.0, 2.0, 5.0]);
-    let item_3 = Item::new("item3", [1.0, 2.0, 2.0]);
+    let item_1 = Item::new("item1", [3, 8, 10]);
+    let item_2 = Item::new("item2", [1, 2, 5]);
+    let item_3 = Item::new("item3", [1, 2, 2]);
     let items = vec![item_1, item_2.clone(), item_2, item_3];
-    let res = packing_algorithm(Bin::new([10.0, 20.0, 20.0]), &items)?;
+    let res = packing_algorithm(Bin::new([10, 20, 20]), &items)?;
     assert_eq!(res, vec![vec!["item1", "item2", "item2", "item3"]]);
     Ok(())
 }
@@ -86,30 +86,30 @@ fn test_odd_sizes() -> Result<()> {
 #[test]
 fn test_odd_sizes_unordered() -> Result<()> {
     // test odd sized items will be sorted to fit.
-    let item_1 = Item::new("item1", [3.0, 8.0, 10.0]);
-    let item_2 = Item::new("item2", [1.0, 2.0, 5.0]);
-    let item_3 = Item::new("item3", [1.0, 2.0, 2.0]);
+    let item_1 = Item::new("item1", [3, 8, 10]);
+    let item_2 = Item::new("item2", [1, 2, 5]);
+    let item_3 = Item::new("item3", [1, 2, 2]);
     let items = vec![item_3, item_2.clone(), item_1, item_2];
-    let res = packing_algorithm(Bin::new([10.0, 20.0, 20.0]), &items)?;
+    let res = packing_algorithm(Bin::new([10, 20, 20]), &items)?;
     assert_eq!(res, vec![vec!["item1", "item2", "item2", "item3"]]);
     Ok(())
 }
 
 #[test]
 fn test_slightly_larger_bin() -> Result<()> {
-    let item = Item::new("item1", [4.0, 4.0, 12.0]);
+    let item = Item::new("item1", [4, 4, 12]);
     let items = vec![item.clone(), item];
-    // let res = packing_algorithm(Bin::new([5.0, 8.0, 12.0]), &items)?;
-    let res = packing_algorithm(Bin::new([4.0, 8.0, 12.0]), &items)?;
+    // let res = packing_algorithm(Bin::new([5, 8, 12]), &items)?;
+    let res = packing_algorithm(Bin::new([4, 8, 12]), &items)?;
     assert_eq!(res, vec![vec!["item1", "item1"]]);
     Ok(())
 }
 
 #[test]
 fn test_pack_3_bins() -> Result<()> {
-    let item = Item::new("item1", [4.0, 4.0, 12.0]);
+    let item = Item::new("item1", [4, 4, 12]);
     let items = vec![item.clone(), item.clone(), item];
-    let res = packing_algorithm(Bin::new([4.0, 4.0, 12.0]), &items)?;
+    let res = packing_algorithm(Bin::new([4, 4, 12]), &items)?;
     assert_eq!(res, vec![vec!["item1"], vec!["item1"], vec!["item1"]]);
     Ok(())
 }
@@ -118,9 +118,9 @@ fn test_pack_3_bins() -> Result<()> {
 fn test_dim_over_2() -> Result<()> {
     // test that when length of item <= length of bin / 2 it packs along longer # edge
 
-    let item = Item::new("item1", [3.0, 4.0, 5.0]);
+    let item = Item::new("item1", [3, 4, 5]);
     let items = (0..=3).map(|_| item.clone()).collect();
-    let res = packing_algorithm(Bin::new([6.0, 8.0, 10.0]), &items)?;
+    let res = packing_algorithm(Bin::new([6, 8, 10]), &items)?;
     assert_eq!(res, vec![["item1"; 4].to_vec()]);
     Ok(())
 }
@@ -129,11 +129,11 @@ fn test_dim_over_2() -> Result<()> {
 fn test_odd_sizes_again() -> Result<()> {
     // test items with different dimensions will be rotated to fit into one bin
 
-    let item_1 = Item::new("item1", [1.0, 18.0, 19.0]);
-    let item_2 = Item::new("item2", [17.0, 18.0, 18.0]);
-    let item_3 = Item::new("item3", [1.0, 17.0, 18.0]);
+    let item_1 = Item::new("item1", [1, 18, 19]);
+    let item_2 = Item::new("item2", [17, 18, 18]);
+    let item_3 = Item::new("item3", [1, 17, 18]);
     let items = vec![item_1, item_2, item_3];
-    let res = packing_algorithm(Bin::new([18.0, 18.0, 19.0]), &items)?;
+    let res = packing_algorithm(Bin::new([18, 18, 19]), &items)?;
     assert_eq!(res, vec![vec!["item1", "item2", "item3"]]);
     Ok(())
 }
@@ -142,9 +142,9 @@ fn test_odd_sizes_again() -> Result<()> {
 fn test_100_items_inexact_fit() -> Result<()> {
     // test many items into one bin with inexact fit
 
-    let item = Item::new("item1", [5.0, 5.0, 5.0]);
+    let item = Item::new("item1", [5, 5, 5]);
     let items = (0..100).map(|_| item.clone()).collect();
-    let res = packing_algorithm(Bin::new([51.0, 51.0, 6.0]), &items)?;
+    let res = packing_algorithm(Bin::new([51, 51, 6]), &items)?;
     assert_eq!(res.len(), 1);
     Ok(())
 }
@@ -153,9 +153,9 @@ fn test_100_items_inexact_fit() -> Result<()> {
 fn test_100_items_inexact_fit_2_bins() -> Result<()> {
     // test many items separated into 2 bins with exact fit
 
-    let item = Item::new("item1", [5.0, 5.0, 5.0]);
+    let item = Item::new("item1", [5, 5, 5]);
     let items = (0..100).map(|_| item.clone()).collect();
-    let res = packing_algorithm(Bin::new([25.0, 10.0, 25.0]), &items)?;
+    let res = packing_algorithm(Bin::new([25, 10, 25]), &items)?;
     assert_eq!(res.len(), 2);
     assert_eq!(res.first().map(|packed| packed.len()), Some(50));
     assert_eq!(res.last().map(|packed| packed.len()), Some(50));
@@ -164,10 +164,10 @@ fn test_100_items_inexact_fit_2_bins() -> Result<()> {
 
 #[test]
 fn test_big_die_and_serveral_decks_of_cards() -> Result<()> {
-    let deck = Item::new("deck", [2.0, 8.0, 12.0]);
-    let die = Item::new("die", [8.0, 8.0, 8.0]);
+    let deck = Item::new("deck", [2, 8, 12]);
+    let die = Item::new("die", [8, 8, 8]);
     let items = vec![deck.clone(), deck.clone(), die, deck.clone(), deck];
-    let res = packing_algorithm(Bin::new([8.0, 8.0, 12.0]), &items)?;
+    let res = packing_algorithm(Bin::new([8, 8, 12]), &items)?;
     assert_eq!(res.len(), 2);
     assert_eq!(res, vec![["deck"; 4].to_vec(), vec!["die"]]);
     Ok(())
@@ -177,9 +177,9 @@ fn test_big_die_and_serveral_decks_of_cards() -> Result<()> {
 fn test_tight_fit_many_oblong() -> Result<()> {
     // tests a tight fit for non-cubic items
 
-    let item_1 = Item::new("item1", [1.0, 2.0, 3.0]);
+    let item_1 = Item::new("item1", [1, 2, 3]);
     let items = (0..107).map(|_| item_1.clone()).collect();
-    let res = packing_algorithm(Bin::new([8.0, 9.0, 9.0]), &items)?;
+    let res = packing_algorithm(Bin::new([8, 9, 9]), &items)?;
     assert_eq!(res.len(), 2);
     assert_eq!(res, vec![["item1"; 106].to_vec(), vec!["item1"]]);
     Ok(())
@@ -190,9 +190,9 @@ fn test_tight_fit_many_oblong_inexact() -> Result<()> {
     // tests that the algorithm remains at least as accurate as it already is. If it were perfect,
     // the first bin would have 48 in it
 
-    let item_1 = Item::new("item1", [1.0, 2.0, 3.0]);
+    let item_1 = Item::new("item1", [1, 2, 3]);
     let items = (0..49).map(|_| item_1.clone()).collect();
-    let res = packing_algorithm(Bin::new([4.0, 8.0, 9.0]), &items)?;
+    let res = packing_algorithm(Bin::new([4, 8, 9]), &items)?;
     assert_eq!(res.len(), 2);
     assert!(res.first().map(|packed| packed.len()) >= Some(44));
     Ok(())
@@ -214,10 +214,10 @@ fn test_flat_bin() -> Result<()> {
 
 #[test]
 fn test_bin_try_packing() -> Result<()> {
-    let item_1 = Item::new("item1", [24.0, 10.0, 2.0]);
-    let item_2 = Item::new("item2", [24.0, 10.0, 2.0]);
-    let item_3 = Item::new("item3", [24.0, 10.0, 2.0]);
-    let mut bin = Bin::new([24.0, 10.0, 4.0]);
+    let item_1 = Item::new("item1", [24, 10, 2]);
+    let item_2 = Item::new("item2", [24, 10, 2]);
+    let item_3 = Item::new("item3", [24, 10, 2]);
+    let mut bin = Bin::new([24, 10, 4]);
     assert!(bin.try_packing(item_1).is_some());
     assert!(bin.try_packing(item_2).is_some());
     assert_eq!(bin.try_packing(item_3), None);


### PR DESCRIPTION
Resolves: https://github.com/modulitos/bin_packer_3d/issues/1

This PR implements a facade for our `Block`, `Bin`, and `Item` constructors, so they can pass in either floats or ints. It does so by leveraging an [Into trait bound](https://doc.rust-lang.org/std/convert/trait.Into.html) on our `Dimension` type.

Unfortunately, I also had to increase the size of `Dimension` from an `f32` to a `f64` to allow users to pass in a u32. Passing in an integer as a u32 allows users to pass in ints easily, (eg: `Bin::new([8, 8, 12])`) instead of having to down-cast them to `u16`, (eg: `Bin::new([8 as u16, 8 as u16, 12 as u16])`)