### PR TITLE
clone item ids

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bin_packer_3d"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["modulitos <modulitos@users.noreply.github.com>"]
 edition = "2018"
 repository = "https://github.com/modulitos/bin_packer_3d"

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -8,14 +8,14 @@ use crate::item::Item;
 /// ```
 
 #[derive(Clone, Debug)]
-pub struct Bin<'a> {
+pub struct Bin {
     /// Represents the cuboid of this bin.
     blocks: Vec<Block>,
     /// Represents the items that are currently packed inside this bin.
-    pub items: Vec<Item<'a>>,
+    pub items: Vec<Item>,
 }
 
-impl<'a> Bin<'a> {
+impl Bin {
     /// Creates a new Bin from it's dimensions.
     pub fn new<F: Into<Dimension> + Copy>(dims: [F; 3]) -> Self {
         Self {
@@ -44,7 +44,7 @@ impl<'a> Bin<'a> {
         assert!(!bin.fits(&item));
     ```
     **/
-    pub fn fits(&self, item: &Item<'_>) -> bool {
+    pub fn fits(&self, item: &Item) -> bool {
         self.blocks
             .iter()
             .any(|block| block.does_it_fit(&item.block))
@@ -69,12 +69,12 @@ impl<'a> Bin<'a> {
             bin.items
                 .into_iter()
                 .map(|item| item.id)
-                .collect::<Vec<&ItemId>>(),
+                .collect::<Vec<ItemId>>(),
             vec!["item1", "item2"]
         );
     ```
     **/
-    pub fn try_packing(&mut self, item: Item<'a>) -> Option<()> {
+    pub fn try_packing(&mut self, item: Item) -> Option<()> {
         let block_to_pack_index =
             self.blocks
                 .iter()

--- a/src/item.rs
+++ b/src/item.rs
@@ -6,26 +6,26 @@ use std::cmp::Ordering::Equal;
 ///
 /// Although it's not enforced, it's highly recommended that each item has a unique ItemId.
 ///
-pub type ItemId = str;
+pub type ItemId = String;
 
 /// Represents an item that a user will insert into a bin.
 /// ```rust
 ///   use bin_packer_3d::item::Item;
 ///   let item = Item::new("deck", [2.0, 8.0, 12.0]);
 /// ```
-#[derive(Clone, Debug, Copy)]
-pub struct Item<'a> {
+#[derive(Clone, Debug)]
+pub struct Item {
     /// a string slice of the id
-    pub id: &'a ItemId,
+    pub id: ItemId,
     /// a Block
     pub block: Block,
 }
 
-impl<'a> Item<'a> {
+impl Item {
     /// Create an item given it's id and dimensions.
-    pub fn new<F: Into<Dimension> + Copy>(id: &'a str, dims: [F; 3]) -> Self {
+    pub fn new<F: Into<Dimension> + Copy>(id: &str, dims: [F; 3]) -> Self {
         Self {
-            id,
+            id: id.into(),
             block: Block::new(dims[0], dims[1], dims[2]),
         }
     }
@@ -35,7 +35,7 @@ impl<'a> Item<'a> {
     }
 }
 
-impl Ord for Item<'_> {
+impl Ord for Item {
     fn cmp(&self, other: &Self) -> Ordering {
         self.get_largest_dim()
             .partial_cmp(&other.get_largest_dim())
@@ -43,16 +43,16 @@ impl Ord for Item<'_> {
     }
 }
 
-impl PartialOrd for Item<'_> {
+impl PartialOrd for Item {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(&other))
     }
 }
 
-impl PartialEq for Item<'_> {
+impl PartialEq for Item {
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
     }
 }
 
-impl<'a> Eq for Item<'a> {}
+impl Eq for Item {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,7 @@
     missing_docs,
     missing_doc_code_examples
 )]
-
 // To use the `unsafe` keyword, change to `#![allow(unsafe_code)]` (do not remove); aids auditing.
-
 #![forbid(unsafe_code)]
 
 /*!
@@ -31,13 +29,16 @@ strategy, along with rotational optimizations.
     use bin_packer_3d::bin::Bin;
     use bin_packer_3d::item::Item;
     use bin_packer_3d::packing_algorithm::packing_algorithm;
-
+    # use bin_packer_3d::error::Result;
+    # fn main() -> Result<()> {
     let deck = Item::new("deck", [2, 8, 12]);
     let die = Item::new("die", [8, 8, 8]);
-    let items = vec![deck, deck, die, deck, deck];
+    let items = vec![deck.clone(), deck.clone(), die, deck.clone(), deck];
 
-    let packed_items = packing_algorithm(Bin::new([8, 8, 12]), &items);
-    assert_eq!(packed_items, Ok(vec![vec!["deck", "deck", "deck", "deck"], vec!["die"]]));
+    let packed_items = packing_algorithm(Bin::new([8, 8, 12]), &items)?;
+    assert_eq!(packed_items, vec![vec!["deck", "deck", "deck", "deck"], vec!["die"]]);
+    # Ok(())
+    # }
 ```
 
 <!-- # /// [more detailed explanation] -->

--- a/src/packing_algorithm.rs
+++ b/src/packing_algorithm.rs
@@ -16,20 +16,24 @@ bins. (first bin is first nested list, second is the second, etc.)
   use bin_packer_3d::bin::Bin;
   use bin_packer_3d::item::Item;
   use bin_packer_3d::packing_algorithm::packing_algorithm;
+  # use bin_packer_3d::error::Result;
+  # fn main() -> Result<()> {
 
   let deck = Item::new("deck", [2.0, 8.0, 12.0]);
   let die = Item::new("die", [8.0, 8.0, 8.0]);
   let items = vec![deck.clone(), deck.clone(), die, deck.clone(), deck];
 
-  let packed_items = packing_algorithm(Bin::new([8.0, 8.0, 12.0]), &items);
-  assert_eq!(packed_items, Ok(vec![vec!["deck", "deck", "deck", "deck"], vec!["die"]]));
+  let packed_items = packing_algorithm(Bin::new([8.0, 8.0, 12.0]), &items).unwrap();
+  assert_eq!(packed_items, vec![vec!["deck", "deck", "deck", "deck"], vec!["die"]]);
+  # Ok(())
+  # }
 ```
 **/
 
-pub fn packing_algorithm<'a>(
-    bin: Bin<'a>,
-    items: &[Item<'a>],
-) -> Result<Vec<Vec<&'a ItemId>>> {
+pub fn packing_algorithm(
+    bin: Bin,
+    items: &[Item],
+) -> Result<Vec<Vec<ItemId>>> {
     if !items.iter().all(|item| bin.fits(item)) {
         return Err(Error::AllItemsMustFit(format!(
             "All items must fit within the bin dimensions."
@@ -42,7 +46,7 @@ pub fn packing_algorithm<'a>(
 
     items_to_pack.sort_by(|a, b| b.cmp(&a));
 
-    let mut packed_bins: Vec<Bin<'a>> = Vec::new();
+    let mut packed_bins: Vec<Bin> = Vec::new();
     let mut bin_currently_packing = bin.clone_as_empty_bin();
 
     loop {

--- a/tests/test_packing_algorithm.rs
+++ b/tests/test_packing_algorithm.rs
@@ -9,7 +9,7 @@ use bin_packer_3d::packing_algorithm::packing_algorithm;
 fn test_pack_items_no_items() -> Result<()> {
     let items = vec![];
     let res = packing_algorithm(Bin::new([3, 4, 5]), &items)?;
-    assert_eq!(res, Vec::<Vec<&ItemId>>::new());
+    assert_eq!(res, Vec::<Vec<ItemId>>::new());
     Ok(())
 }
 
@@ -36,7 +36,7 @@ fn test_pack_items_one_item() -> Result<()> {
 fn test_pack_items_two_item_exact() -> Result<()> {
     let bin = Bin::new([13, 26, 31]);
     let item_1 = Item::new("item1", [13, 13, 31]);
-    let items = vec![item_1, item_1];
+    let items = vec![item_1.clone(), item_1];
     let res = packing_algorithm(bin, &items)?;
     assert_eq!(res, vec![vec!["item1", "item1"]]);
     Ok(())
@@ -45,7 +45,7 @@ fn test_pack_items_two_item_exact() -> Result<()> {
 #[test]
 fn test_two_items_two_bins() -> Result<()> {
     let item = Item::new("item1", [13, 13, 31]);
-    let items = vec![item, item];
+    let items = vec![item.clone(), item];
     let res = packing_algorithm(Bin::new([13, 13, 31]), &items)?;
     assert_eq!(res, vec![vec!["item1"], vec!["item1"]]);
     Ok(())
@@ -65,7 +65,7 @@ fn test_three_items_one_bin() -> Result<()> {
 #[test]
 fn test_one_overflow() -> Result<()> {
     let item = Item::new("item1", [1, 1, 1]);
-    let items = [item; 28];
+    let items = (0..28).map(|_| item.clone()).collect::<Vec<Item>>();
     let res = packing_algorithm(Bin::new([3, 3, 3]), &items)?;
     assert_eq!(res, vec![["item1"; 27].to_vec(), vec!["item1"]]);
     Ok(())
@@ -76,7 +76,7 @@ fn test_odd_sizes() -> Result<()> {
     let item_1 = Item::new("item1", [3, 8, 10]);
     let item_2 = Item::new("item2", [1, 2, 5]);
     let item_3 = Item::new("item3", [1, 2, 2]);
-    let items = vec![item_1, item_2, item_2, item_3];
+    let items = vec![item_1, item_2.clone(), item_2, item_3];
     let res = packing_algorithm(Bin::new([10, 20, 20]), &items)?;
     assert_eq!(res, vec![vec!["item1", "item2", "item2", "item3"]]);
     Ok(())
@@ -88,7 +88,7 @@ fn test_odd_sizes_unordered() -> Result<()> {
     let item_1 = Item::new("item1", [3, 8, 10]);
     let item_2 = Item::new("item2", [1, 2, 5]);
     let item_3 = Item::new("item3", [1, 2, 2]);
-    let items = vec![item_3, item_2, item_1, item_2];
+    let items = vec![item_3, item_2.clone(), item_1, item_2];
     let res = packing_algorithm(Bin::new([10, 20, 20]), &items)?;
     assert_eq!(res, vec![vec!["item1", "item2", "item2", "item3"]]);
     Ok(())
@@ -97,8 +97,7 @@ fn test_odd_sizes_unordered() -> Result<()> {
 #[test]
 fn test_slightly_larger_bin() -> Result<()> {
     let item = Item::new("item1", [4, 4, 12]);
-    let items = vec![item, item];
-    // let res = packing_algorithm(Bin::new([5, 8, 12]), &items)?;
+    let items = vec![item.clone(), item];
     let res = packing_algorithm(Bin::new([4, 8, 12]), &items)?;
     assert_eq!(res, vec![vec!["item1", "item1"]]);
     Ok(())
@@ -107,7 +106,7 @@ fn test_slightly_larger_bin() -> Result<()> {
 #[test]
 fn test_pack_3_bins() -> Result<()> {
     let item = Item::new("item1", [4, 4, 12]);
-    let items = vec![item, item, item];
+    let items = vec![item.clone(), item.clone(), item];
     let res = packing_algorithm(Bin::new([4, 4, 12]), &items)?;
     assert_eq!(res, vec![vec!["item1"], vec!["item1"], vec!["item1"]]);
     Ok(())
@@ -118,7 +117,7 @@ fn test_dim_over_2() -> Result<()> {
     // test that when length of item <= length of bin / 2 it packs along longer # edge
 
     let item = Item::new("item1", [3, 4, 5]);
-    let items = [item; 4];
+    let items = (0..4).map(|_| item.clone()).collect::<Vec<Item>>();
     let res = packing_algorithm(Bin::new([6, 8, 10]), &items)?;
     assert_eq!(res, vec![["item1"; 4].to_vec()]);
     Ok(())
@@ -142,7 +141,7 @@ fn test_100_items_inexact_fit() -> Result<()> {
     // test many items into one bin with inexact fit
 
     let item = Item::new("item1", [5, 5, 5]);
-    let items = [item; 100];
+    let items = (0..100).map(|_| item.clone()).collect::<Vec<Item>>();
     let res = packing_algorithm(Bin::new([51, 51, 6]), &items)?;
     assert_eq!(res.len(), 1);
     Ok(())
@@ -153,7 +152,7 @@ fn test_100_items_inexact_fit_2_bins() -> Result<()> {
     // test many items separated into 2 bins with exact fit
 
     let item = Item::new("item1", [5, 5, 5]);
-    let items = [item; 100];
+    let items = (0..100).map(|_| item.clone()).collect::<Vec<Item>>();
     let res = packing_algorithm(Bin::new([25, 10, 25]), &items)?;
     assert_eq!(res.len(), 2);
     assert_eq!(res.first().map(|packed| packed.len()), Some(50));
@@ -165,7 +164,7 @@ fn test_100_items_inexact_fit_2_bins() -> Result<()> {
 fn test_big_die_and_serveral_decks_of_cards() -> Result<()> {
     let deck = Item::new("deck", [2, 8, 12]);
     let die = Item::new("die", [8, 8, 8]);
-    let items = vec![deck, deck, die, deck, deck];
+    let items = vec![deck.clone(), deck.clone(), die, deck.clone(), deck];
     let res = packing_algorithm(Bin::new([8, 8, 12]), &items)?;
     assert_eq!(res.len(), 2);
     assert_eq!(res, vec![["deck"; 4].to_vec(), vec!["die"]]);
@@ -177,7 +176,7 @@ fn test_tight_fit_many_oblong() -> Result<()> {
     // tests a tight fit for non-cubic items
 
     let item = Item::new("item1", [1, 2, 3]);
-    let items = [item; 107];
+    let items = (0..107).map(|_| item.clone()).collect::<Vec<Item>>();
     let res = packing_algorithm(Bin::new([8, 9, 9]), &items)?;
     assert_eq!(res.len(), 2);
     assert_eq!(res, vec![["item1"; 106].to_vec(), vec!["item1"]]);
@@ -189,7 +188,7 @@ fn test_tight_fit_many_oblong_inexact() -> Result<()> {
     // tests that the algorithm remains at least as accurate as it already is. If it were perfect,
     // the first bin would have 48 in it
     let item = Item::new("item1", [1, 2, 3]);
-    let items = [item; 49];
+    let items = (0..48).map(|_| item.clone()).collect::<Vec<Item>>();
     let res = packing_algorithm(Bin::new([4, 8, 9]), &items)?;
     assert_eq!(res.len(), 2);
     assert!(res.first().map(|packed| packed.len()) >= Some(44));
@@ -199,7 +198,7 @@ fn test_tight_fit_many_oblong_inexact() -> Result<()> {
 #[test]
 fn test_flat_bin() -> Result<()> {
     let item_1 = Item::new("item1", [1.25, 7.0, 10.0]);
-    let items = vec![item_1, item_1, item_1];
+    let items = vec![item_1.clone(), item_1.clone(), item_1];
     let res = packing_algorithm(Bin::new([3.5, 9.5, 12.5]), &items)?;
     assert_eq!(res.len(), 2);
     assert_eq!(res.first().map(|packed| packed.len()), Some(2));
@@ -223,7 +222,7 @@ fn test_bin_try_packing() -> Result<()> {
         bin.items
             .into_iter()
             .map(|item| item.id)
-            .collect::<Vec<&ItemId>>(),
+            .collect::<Vec<ItemId>>(),
         vec!["item1", "item2"]
     );
     Ok(())


### PR DESCRIPTION
It's more ergonomical for a client library to pass in strings for their item ids, and not have to worry about maintaining references to those items. Although there's a slight perf hit in cloning the strings, it seems like a worthwhile tradeoff. We don't expect cloning items to be a significant factor in the performance of the algorithm...